### PR TITLE
feat(android): add acknowledgeEvent for background upload events

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Documentation for the [Capacitor Camera preview](https://github.com/Cap-go/camer
 * [`startUpload(...)`](#startupload)
 * [`removeUpload(...)`](#removeupload)
 * [`addListener('events', ...)`](#addlistenerevents-)
+* [`acknowledgeEvent(...)`](#acknowledgeevent)
 * [`getPluginVersion()`](#getpluginversion)
 * [Interfaces](#interfaces)
 
@@ -348,6 +349,30 @@ Events are fired for:
 --------------------
 
 
+### acknowledgeEvent(...)
+
+```typescript
+acknowledgeEvent(options: { eventId: string; }) => Promise<void>
+```
+
+Acknowledge receipt of an upload event and remove it from the plugin cache.
+
+Completed and failed events are stored in the plugin's persistent cache so they can be
+re-delivered if the app is closed or backgrounded before the event is processed.
+Call this method after successfully handling a 'completed' or 'failed' event to prevent
+it from being re-broadcast the next time the plugin initialises.
+
+Progress ('uploading') events do not have an eventId and do not need to be acknowledged.
+
+| Param         | Type                              | Description                                    |
+| ------------- | --------------------------------- | ---------------------------------------------- |
+| **`options`** | <code>{ eventId: string; }</code> | - Object containing the eventId to acknowledge |
+
+**Since:** 0.0.2
+
+--------------------
+
+
 ### getPluginVersion()
 
 ```typescript
@@ -405,11 +430,12 @@ Configuration options for uploading a file.
 
 Event emitted during the upload lifecycle.
 
-| Prop          | Type                                                                    | Description                                                                                                                                                | Since |
-| ------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
-| **`name`**    | <code>'uploading' \| 'completed' \| 'failed'</code>                     | The current status of the upload. - 'uploading': Upload is in progress - 'completed': Upload finished successfully - 'failed': Upload encountered an error | 0.0.1 |
-| **`payload`** | <code>{ percent?: number; error?: string; statusCode?: number; }</code> | Additional data about the upload event.                                                                                                                    | 0.0.1 |
-| **`id`**      | <code>string</code>                                                     | Unique identifier for this upload task.                                                                                                                    | 0.0.1 |
+| Prop          | Type                                                                    | Description                                                                                                                                                                                                                                                                  | Since |
+| ------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| **`name`**    | <code>'uploading' \| 'completed' \| 'failed'</code>                     | The current status of the upload. - 'uploading': Upload is in progress - 'completed': Upload finished successfully - 'failed': Upload encountered an error                                                                                                                   | 0.0.1 |
+| **`payload`** | <code>{ percent?: number; error?: string; statusCode?: number; }</code> | Additional data about the upload event.                                                                                                                                                                                                                                      | 0.0.1 |
+| **`id`**      | <code>string</code>                                                     | Unique identifier for this upload task.                                                                                                                                                                                                                                      | 0.0.1 |
+| **`eventId`** | <code>string</code>                                                     | Unique identifier for this specific event instance. Only present on 'completed' and 'failed' events. Used with acknowledgeEvent() to confirm receipt and remove the event from the plugin cache. Progress ('uploading') events do not have an eventId and are not persisted. | 0.0.2 |
 
 </docgen-api>
 

--- a/android/src/main/java/ee/forgr/capacitor/uploader/UploaderPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor/uploader/UploaderPlugin.java
@@ -3,8 +3,10 @@ package ee.forgr.capacitor.uploader;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Build;
+import android.util.Log;
 import android.webkit.MimeTypeMap;
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
@@ -16,10 +18,12 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.UUID;
 import net.gotev.uploadservice.data.UploadInfo;
 import net.gotev.uploadservice.network.ServerResponse;
 import net.gotev.uploadservice.observer.request.RequestObserver;
 import net.gotev.uploadservice.observer.request.RequestObserverDelegate;
+import org.json.JSONException;
 import org.json.JSONObject;
 
 @CapacitorPlugin(name = "Uploader")
@@ -36,6 +40,51 @@ public class UploaderPlugin extends Plugin {
     private static final String CHANNEL_ID = "ee.forgr.capacitor.uploader.notification_channel_id";
     private static final String CHANNEL_NAME = "Uploader Notifications";
     private static final String CHANNEL_DESCRIPTION = "Notifications for file uploads";
+
+    private static final String PREFS_NAME = "CapacitorUploaderPrefs";
+    private static final String PENDING_EVENTS_KEY = "pending_events";
+    private static final String TAG = "UploaderPlugin";
+
+    private void saveEventToPrefs(String eventId, JSObject event) {
+        SharedPreferences prefs = getContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        String existingJson = prefs.getString(PENDING_EVENTS_KEY, "{}");
+        try {
+            JSONObject pendingEvents = new JSONObject(existingJson);
+            pendingEvents.put(eventId, new JSONObject(event.toString()));
+            prefs.edit().putString(PENDING_EVENTS_KEY, pendingEvents.toString()).apply();
+        } catch (JSONException e) {
+            Log.e(TAG, "Failed to persist upload event", e);
+        }
+    }
+
+    private void removeEventFromPrefs(String eventId) {
+        SharedPreferences prefs = getContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        String existingJson = prefs.getString(PENDING_EVENTS_KEY, "{}");
+        try {
+            JSONObject pendingEvents = new JSONObject(existingJson);
+            pendingEvents.remove(eventId);
+            prefs.edit().putString(PENDING_EVENTS_KEY, pendingEvents.toString()).apply();
+        } catch (JSONException e) {
+            Log.e(TAG, "Failed to remove upload event from prefs", e);
+        }
+    }
+
+    private void replayPendingEvents() {
+        SharedPreferences prefs = getContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        String existingJson = prefs.getString(PENDING_EVENTS_KEY, "{}");
+        try {
+            JSONObject pendingEvents = new JSONObject(existingJson);
+            Iterator<String> keys = pendingEvents.keys();
+            while (keys.hasNext()) {
+                String eventId = keys.next();
+                JSONObject eventJson = pendingEvents.getJSONObject(eventId);
+                JSObject event = JSObject.fromJSONObject(eventJson);
+                notifyListeners("events", event);
+            }
+        } catch (JSONException e) {
+            Log.e(TAG, "Failed to replay pending upload events", e);
+        }
+    }
 
     private void createNotificationChannel() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -76,6 +125,9 @@ public class UploaderPlugin extends Plugin {
                     payload.put("statusCode", serverResponse.getCode());
                     event.put("payload", payload);
                     event.put("id", uploadInfo.getUploadId());
+                    String eventId = UUID.randomUUID().toString();
+                    event.put("eventId", eventId);
+                    saveEventToPrefs(eventId, event);
                     notifyListeners("events", event);
                 }
 
@@ -87,6 +139,9 @@ public class UploaderPlugin extends Plugin {
                     payload.put("error", exception.getMessage());
                     event.put("payload", payload);
                     event.put("id", uploadInfo.getUploadId());
+                    String eventId = UUID.randomUUID().toString();
+                    event.put("eventId", eventId);
+                    saveEventToPrefs(eventId, event);
                     notifyListeners("events", event);
                 }
 
@@ -100,12 +155,13 @@ public class UploaderPlugin extends Plugin {
 
                 @Override
                 public void onCompletedWhileNotObserving() {
-                    // Handle completion while not observing if needed
+                    replayPendingEvents();
                 }
             }
         );
 
         implementation = new Uploader(getContext().getApplicationContext());
+        replayPendingEvents();
     }
 
     public static String getMimeType(String url) {
@@ -261,6 +317,17 @@ public class UploaderPlugin extends Plugin {
             }
         }
         return map;
+    }
+
+    @PluginMethod
+    public void acknowledgeEvent(PluginCall call) {
+        String eventId = call.getString("eventId");
+        if (eventId == null || eventId.isEmpty()) {
+            call.reject("Missing required parameter: eventId");
+            return;
+        }
+        removeEventFromPrefs(eventId);
+        call.resolve();
     }
 
     @PluginMethod

--- a/ios/Sources/UploaderPlugin/UploaderPlugin.swift
+++ b/ios/Sources/UploaderPlugin/UploaderPlugin.swift
@@ -9,7 +9,8 @@ public class UploaderPlugin: CAPPlugin, CAPBridgedPlugin {
     public let pluginMethods: [CAPPluginMethod] = [
         CAPPluginMethod(name: "startUpload", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "removeUpload", returnType: CAPPluginReturnPromise),
-        CAPPluginMethod(name: "getPluginVersion", returnType: CAPPluginReturnPromise)
+        CAPPluginMethod(name: "getPluginVersion", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "acknowledgeEvent", returnType: CAPPluginReturnPromise)
     ]
     private let implementation = Uploader()
 
@@ -66,6 +67,14 @@ public class UploaderPlugin: CAPPlugin, CAPBridgedPlugin {
                 call.reject("Failed to start upload: \(error.localizedDescription)")
             }
         }
+    }
+
+    @objc func acknowledgeEvent(_ call: CAPPluginCall) {
+        guard let eventId = call.getString("eventId"), !eventId.isEmpty else {
+            call.reject("Missing required parameter: eventId")
+            return
+        }
+        call.resolve()
     }
 
     @objc func removeUpload(_ call: CAPPluginCall) {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -197,6 +197,16 @@ export interface UploadEvent {
    * @since 0.0.1
    */
   id: string;
+
+  /**
+   * Unique identifier for this specific event instance.
+   * Only present on 'completed' and 'failed' events.
+   * Used with acknowledgeEvent() to confirm receipt and remove the event from the plugin cache.
+   * Progress ('uploading') events do not have an eventId and are not persisted.
+   *
+   * @since 0.0.2
+   */
+  eventId?: string;
 }
 
 /**
@@ -319,6 +329,33 @@ export interface UploaderPlugin {
    * ```
    */
   addListener(eventName: 'events', listenerFunc: (state: UploadEvent) => void): Promise<PluginListenerHandle>;
+
+  /**
+   * Acknowledge receipt of an upload event and remove it from the plugin cache.
+   *
+   * Completed and failed events are stored in the plugin's persistent cache so they can be
+   * re-delivered if the app is closed or backgrounded before the event is processed.
+   * Call this method after successfully handling a 'completed' or 'failed' event to prevent
+   * it from being re-broadcast the next time the plugin initialises.
+   *
+   * Progress ('uploading') events do not have an eventId and do not need to be acknowledged.
+   *
+   * @param options - Object containing the eventId to acknowledge
+   * @returns Promise that resolves when the event has been removed from the cache
+   * @since 0.0.2
+   * @example
+   * ```typescript
+   * const listener = await Uploader.addListener('events', async (event) => {
+   *   if (event.name === 'completed' || event.name === 'failed') {
+   *     handleUploadResult(event);
+   *     if (event.eventId) {
+   *       await Uploader.acknowledgeEvent({ eventId: event.eventId });
+   *     }
+   *   }
+   * });
+   * ```
+   */
+  acknowledgeEvent(options: { eventId: string }): Promise<void>;
 
   /**
    * Get the native Capacitor plugin version.

--- a/src/web.ts
+++ b/src/web.ts
@@ -174,6 +174,10 @@ export class UploaderWeb extends WebPlugin implements UploaderPlugin {
     }
   }
 
+  async acknowledgeEvent(_options: { eventId: string }): Promise<void> {
+    // Web uploads run in-process; events are not persisted for replay.
+  }
+
   async getPluginVersion(): Promise<{ version: string }> {
     return { version: 'web' };
   }


### PR DESCRIPTION
## Summary
- Add `eventId` on Android `completed` and `failed` upload events and persist them in SharedPreferences for replay when the WebView listener was inactive (background/sleep).
- Add `Uploader.acknowledgeEvent({ eventId })` to remove acknowledged events from the cache and stop re-delivery on plugin load.
- Replay pending events on plugin load and when upload observation resumes (`onCompletedWhileNotObserving`).

Fixes #57

## Test plan
- [x] `bun run verify` (iOS, Android, web)
- [ ] Manual: start a large upload on Android, background the app, foreground, confirm completed/failed events replay with stable `eventId`, then call `acknowledgeEvent` and confirm they are not replayed again after restart


Made with [Cursor](https://cursor.com)