### PR TITLE
fix(android): stream multipart uploads to avoid OOM

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor/uploader/Uploader.java
+++ b/android/src/main/java/ee/forgr/capacitor/uploader/Uploader.java
@@ -5,17 +5,29 @@ import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
 import android.provider.OpenableColumns;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import net.gotev.uploadservice.UploadServiceConfig;
 import net.gotev.uploadservice.data.UploadNotificationConfig;
 import net.gotev.uploadservice.data.UploadNotificationStatusConfig;
 import net.gotev.uploadservice.protocols.binary.BinaryUploadRequest;
-import net.gotev.uploadservice.protocols.multipart.MultipartUploadRequest;
 
 public class Uploader {
 
+    private static final int STREAM_BUFFER_SIZE = 64 * 1024;
+
     private final Context context;
+    private final Map<String, File> tempMultipartBodies = new ConcurrentHashMap<>();
 
     public static class UploadFile {
 
@@ -70,31 +82,7 @@ public class Uploader {
             if (files == null || files.isEmpty()) {
                 throw new IllegalArgumentException("Missing required parameter: files");
             }
-            MultipartUploadRequest request = new MultipartUploadRequest(context, serverUrl)
-                .setMethod(httpMethod)
-                .setNotificationConfig((ctx, uploadId) -> notificationConfig)
-                .setMaxRetries(maxRetries);
-
-            for (UploadFile file : files) {
-                if (file == null || file.filePath == null || file.filePath.isEmpty()) {
-                    throw new IllegalArgumentException("Invalid file entry in files");
-                }
-                String fieldName = (file.fieldName == null || file.fieldName.isEmpty()) ? "file" : file.fieldName;
-                request.addFileToUpload(file.filePath, fieldName, getFileNameFromUri(Uri.parse(file.filePath)), file.mimeType);
-            }
-
-            for (Map.Entry<String, String> entry : headers.entrySet()) {
-                if (entry.getKey() != null && entry.getValue() != null) {
-                    request.addHeader(entry.getKey(), entry.getValue());
-                }
-            }
-            for (Map.Entry<String, String> entry : parameters.entrySet()) {
-                if (entry.getKey() != null && entry.getValue() != null) {
-                    request.addParameter(entry.getKey(), entry.getValue());
-                }
-            }
-
-            return request.startUpload();
+            return startMultipartUpload(files, serverUrl, headers, parameters, httpMethod, notificationConfig, maxRetries);
         } else {
             if (files == null || files.isEmpty()) {
                 throw new IllegalArgumentException("Missing required parameter: filePath or files");
@@ -113,6 +101,141 @@ public class Uploader {
                 maxRetries,
                 file.mimeType
             );
+        }
+    }
+
+    private String startMultipartUpload(
+        List<UploadFile> files,
+        String serverUrl,
+        Map<String, String> headers,
+        Map<String, String> parameters,
+        String httpMethod,
+        UploadNotificationConfig notificationConfig,
+        int maxRetries
+    ) throws Exception {
+        String boundary = UUID.randomUUID().toString();
+        File tempBody = writeMultipartBodyToFile(files, parameters, boundary);
+
+        try {
+            BinaryUploadRequest request = new BinaryUploadRequest(context, serverUrl)
+                .setMethod(httpMethod)
+                .setFileToUpload(tempBody.getAbsolutePath())
+                .setNotificationConfig((ctx, uploadId) -> notificationConfig)
+                .setMaxRetries(maxRetries)
+                .setUsesFixedLengthStreamingMode(true);
+
+            request.addHeader("Content-Type", "multipart/form-data; boundary=" + boundary);
+
+            for (Map.Entry<String, String> entry : headers.entrySet()) {
+                if (entry.getKey() != null && entry.getValue() != null) {
+                    request.addHeader(entry.getKey(), entry.getValue());
+                }
+            }
+
+            String uploadId = request.startUpload();
+            tempMultipartBodies.put(uploadId, tempBody);
+            return uploadId;
+        } catch (Exception e) {
+            if (!tempBody.delete()) {
+                tempBody.deleteOnExit();
+            }
+            throw e;
+        }
+    }
+
+    private File writeMultipartBodyToFile(List<UploadFile> files, Map<String, String> parameters, String boundary)
+        throws IOException {
+        File tempFile = File.createTempFile("upload-", ".tmp", context.getCacheDir());
+
+        try (FileOutputStream output = new FileOutputStream(tempFile)) {
+            if (parameters != null) {
+                for (Map.Entry<String, String> entry : parameters.entrySet()) {
+                    if (entry.getKey() == null || entry.getValue() == null) {
+                        continue;
+                    }
+                    writeUtf8(output, "--" + boundary + "\r\n");
+                    writeUtf8(output, "Content-Disposition: form-data; name=\"" + entry.getKey() + "\"\r\n\r\n");
+                    writeUtf8(output, entry.getValue() + "\r\n");
+                }
+            }
+
+            for (UploadFile file : files) {
+                if (file == null || file.filePath == null || file.filePath.isEmpty()) {
+                    throw new IllegalArgumentException("Invalid file entry in files");
+                }
+
+                String fieldName = (file.fieldName == null || file.fieldName.isEmpty()) ? "file" : file.fieldName;
+                String fileName = getFileNameFromUri(Uri.parse(file.filePath));
+                if (fileName == null || fileName.isEmpty()) {
+                    fileName = "file";
+                }
+                String mimeType = (file.mimeType == null || file.mimeType.isEmpty())
+                    ? "application/octet-stream"
+                    : file.mimeType;
+
+                writeUtf8(output, "--" + boundary + "\r\n");
+                writeUtf8(
+                    output,
+                    "Content-Disposition: form-data; name=\"" +
+                    fieldName +
+                    "\"; filename=\"" +
+                    fileName +
+                    "\"\r\n"
+                );
+                writeUtf8(output, "Content-Type: " + mimeType + "\r\n\r\n");
+                streamFileToOutput(file.filePath, output);
+                writeUtf8(output, "\r\n");
+            }
+
+            writeUtf8(output, "--" + boundary + "--\r\n");
+        } catch (IOException | RuntimeException e) {
+            if (!tempFile.delete()) {
+                tempFile.deleteOnExit();
+            }
+            throw e;
+        }
+
+        return tempFile;
+    }
+
+    private void writeUtf8(OutputStream output, String value) throws IOException {
+        output.write(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private void streamFileToOutput(String filePath, OutputStream output) throws IOException {
+        try (InputStream input = openInputStream(filePath)) {
+            byte[] buffer = new byte[STREAM_BUFFER_SIZE];
+            int read;
+            while ((read = input.read(buffer)) != -1) {
+                output.write(buffer, 0, read);
+            }
+        }
+    }
+
+    private InputStream openInputStream(String filePath) throws IOException {
+        if (filePath.startsWith("content://")) {
+            InputStream stream = context.getContentResolver().openInputStream(Uri.parse(filePath));
+            if (stream == null) {
+                throw new FileNotFoundException("Cannot open content URI: " + filePath);
+            }
+            return stream;
+        }
+
+        if (filePath.startsWith("file://")) {
+            String path = Uri.parse(filePath).getPath();
+            if (path == null) {
+                throw new FileNotFoundException("Invalid file URI: " + filePath);
+            }
+            return new FileInputStream(path);
+        }
+
+        return new FileInputStream(filePath);
+    }
+
+    public void clearTempMultipartBody(String uploadId) {
+        File tempFile = tempMultipartBodies.remove(uploadId);
+        if (tempFile != null && !tempFile.delete()) {
+            tempFile.deleteOnExit();
         }
     }
 
@@ -152,6 +275,7 @@ public class Uploader {
     }
 
     public void removeUpload(String uploadId) {
+        clearTempMultipartBody(uploadId);
         net.gotev.uploadservice.UploadService.stopUpload(uploadId);
     }
 

--- a/android/src/main/java/ee/forgr/capacitor/uploader/Uploader.java
+++ b/android/src/main/java/ee/forgr/capacitor/uploader/Uploader.java
@@ -143,8 +143,7 @@ public class Uploader {
         }
     }
 
-    private File writeMultipartBodyToFile(List<UploadFile> files, Map<String, String> parameters, String boundary)
-        throws IOException {
+    private File writeMultipartBodyToFile(List<UploadFile> files, Map<String, String> parameters, String boundary) throws IOException {
         File tempFile = File.createTempFile("upload-", ".tmp", context.getCacheDir());
 
         try (FileOutputStream output = new FileOutputStream(tempFile)) {
@@ -169,19 +168,10 @@ public class Uploader {
                 if (fileName == null || fileName.isEmpty()) {
                     fileName = "file";
                 }
-                String mimeType = (file.mimeType == null || file.mimeType.isEmpty())
-                    ? "application/octet-stream"
-                    : file.mimeType;
+                String mimeType = (file.mimeType == null || file.mimeType.isEmpty()) ? "application/octet-stream" : file.mimeType;
 
                 writeUtf8(output, "--" + boundary + "\r\n");
-                writeUtf8(
-                    output,
-                    "Content-Disposition: form-data; name=\"" +
-                    fieldName +
-                    "\"; filename=\"" +
-                    fileName +
-                    "\"\r\n"
-                );
+                writeUtf8(output, "Content-Disposition: form-data; name=\"" + fieldName + "\"; filename=\"" + fileName + "\"\r\n");
                 writeUtf8(output, "Content-Type: " + mimeType + "\r\n\r\n");
                 streamFileToOutput(file.filePath, output);
                 writeUtf8(output, "\r\n");

--- a/android/src/main/java/ee/forgr/capacitor/uploader/UploaderPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor/uploader/UploaderPlugin.java
@@ -119,6 +119,7 @@ public class UploaderPlugin extends Plugin {
 
                 @Override
                 public void onSuccess(Context context, UploadInfo uploadInfo, ServerResponse serverResponse) {
+                    implementation.clearTempMultipartBody(uploadInfo.getUploadId());
                     JSObject event = new JSObject();
                     event.put("name", "completed");
                     JSObject payload = new JSObject();
@@ -133,6 +134,7 @@ public class UploaderPlugin extends Plugin {
 
                 @Override
                 public void onError(Context context, UploadInfo uploadInfo, Throwable exception) {
+                    implementation.clearTempMultipartBody(uploadInfo.getUploadId());
                     JSObject event = new JSObject();
                     event.put("name", "failed");
                     JSObject payload = new JSObject();
@@ -147,6 +149,7 @@ public class UploaderPlugin extends Plugin {
 
                 @Override
                 public void onCompleted(Context context, UploadInfo uploadInfo) {
+                    implementation.clearTempMultipartBody(uploadInfo.getUploadId());
                     JSObject event = new JSObject();
                     event.put("name", "finished");
                     event.put("id", uploadInfo.getUploadId());
@@ -293,9 +296,9 @@ public class UploaderPlugin extends Plugin {
                     if (uri.getPort() != -1) {
                         baseUrl += ":" + uri.getPort();
                     }
-                    return filePath.replace(baseUrl + CAPACITOR_CONTENT_PATH_PREFIX, "content:/");
+                    return filePath.replace(baseUrl + CAPACITOR_CONTENT_PATH_PREFIX, "content://");
                 }
-                return filePath.replace(CAPACITOR_CONTENT_PATH_PREFIX, "content:/");
+                return filePath.replace(CAPACITOR_CONTENT_PATH_PREFIX, "content://");
             }
         }
         if ("file".equalsIgnoreCase(uri.getScheme()) && uri.getPath() != null) {


### PR DESCRIPTION
## Summary
- Fixes #159 by building Android multipart upload bodies in a temp file using 64KB chunked reads (mirrors the iOS streaming approach)
- Uploads the assembled temp file via `BinaryUploadRequest` so large files are never held fully in heap memory
- Cleans up temp multipart files on upload success, error, completion, or cancellation
- Fixes Capacitor content URL normalization (`content://` instead of `content:/`)

## Test plan
- [x] `bun install`
- [x] `bun run verify` (iOS, Android, web)
- [ ] Manual: upload a large file (>100MB) on Android via multipart POST
- [ ] Manual: verify upload progress/completed events still fire
- [ ] Manual: verify binary (PUT) uploads still work


Made with [Cursor](https://cursor.com)