### PR TITLE
[codex] add multipart upload support

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Documentation for the [Capacitor Camera preview](https://github.com/Cap-go/camer
 <docgen-index>
 
 * [`startUpload(...)`](#startupload)
+* [`uploadMultipart(...)`](#uploadmultipart)
 * [`removeUpload(...)`](#removeupload)
 * [`addListener('events', ...)`](#addlistenerevents-)
 * [`acknowledgeEvent(...)`](#acknowledgeevent)
@@ -301,6 +302,28 @@ Listen to upload events to track progress, completion, or failure.
 **Returns:** <code>Promise&lt;{ id: string; }&gt;</code>
 
 **Since:** 0.0.1
+
+--------------------
+
+
+### uploadMultipart(...)
+
+```typescript
+uploadMultipart(options: UploadMultipartOptions) => Promise<{ id: string; }>
+```
+
+Start uploading a single file as multipart/form-data.
+
+This is a convenience API for backends that expect a named file field and
+additional form fields. Existing `startUpload` binary uploads are unchanged.
+
+| Param         | Type                                                                      | Description                              |
+| ------------- | ------------------------------------------------------------------------- | ---------------------------------------- |
+| **`options`** | <code><a href="#uploadmultipartoptions">UploadMultipartOptions</a></code> | - Configuration for the multipart upload |
+
+**Returns:** <code>Promise&lt;{ id: string; }&gt;</code>
+
+**Since:** 8.3.2
 
 --------------------
 
@@ -417,6 +440,19 @@ Configuration options for uploading a file.
 | **`filePath`**  | <code>string</code> | The local file path of the file to upload. Can be a file:// URL or an absolute path.                                                                                | 0.0.3 |
 | **`fieldName`** | <code>string</code> | The form field name for the file part when using multipart upload. If omitted, <a href="#uploadoption">`uploadOption.fileField`</a> is used (defaults to `'file'`). | 0.0.3 |
 | **`mimeType`**  | <code>string</code> | The MIME type of this file. If not specified, the plugin will attempt to determine it automatically.                                                                | 0.0.3 |
+
+
+#### UploadMultipartOptions
+
+Options for starting a single-file multipart upload.
+
+| Prop            | Type                                    | Description                                                                          | Since |
+| --------------- | --------------------------------------- | ------------------------------------------------------------------------------------ | ----- |
+| **`url`**       | <code>string</code>                     | The server URL endpoint where the multipart request should be sent.                  | 8.3.2 |
+| **`filePath`**  | <code>string</code>                     | The local file path of the file to upload. Can be a file:// URL or an absolute path. | 8.3.2 |
+| **`fieldName`** | <code>string</code>                     | The form field name for the uploaded file part.                                      | 8.3.2 |
+| **`fields`**    | <code>{ [key: string]: string; }</code> | Additional form fields to include in the multipart request.                          | 8.3.2 |
+| **`headers`**   | <code>{ [key: string]: string; }</code> | HTTP headers to send with the upload request.                                        | 8.3.2 |
 
 
 #### PluginListenerHandle

--- a/android/src/main/java/ee/forgr/capacitor/uploader/UploaderPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor/uploader/UploaderPlugin.java
@@ -259,6 +259,46 @@ public class UploaderPlugin extends Plugin {
     }
 
     @PluginMethod
+    public void uploadMultipart(PluginCall call) {
+        String serverUrl = call.getString("url");
+        if (serverUrl == null || serverUrl.isEmpty()) {
+            call.reject("Missing required parameter: url");
+            return;
+        }
+
+        String filePath = call.getString("filePath");
+        if (filePath == null || filePath.isEmpty()) {
+            call.reject("Missing required parameter: filePath");
+            return;
+        }
+
+        String fieldName = call.getString("fieldName");
+        if (fieldName == null || fieldName.isEmpty()) {
+            call.reject("Missing required parameter: fieldName");
+            return;
+        }
+
+        JSObject headersObj = call.getObject("headers", new JSObject());
+        JSObject fieldsObj = call.getObject("fields", new JSObject());
+        Map<String, String> headers = JSObjectToMap(headersObj);
+        Map<String, String> fields = JSObjectToMap(fieldsObj);
+
+        try {
+            String localFilePath = resolveCapacitorPath(filePath);
+            String mimeType = getMimeType(localFilePath);
+            ArrayList<Uploader.UploadFile> filesToUpload = new ArrayList<>();
+            filesToUpload.add(new Uploader.UploadFile(localFilePath, fieldName, mimeType));
+
+            String id = implementation.startUpload(filesToUpload, serverUrl, headers, fields, "POST", "File Upload", 2, "multipart");
+            JSObject result = new JSObject();
+            result.put("id", id);
+            call.resolve(result);
+        } catch (Exception e) {
+            call.reject(e.getMessage());
+        }
+    }
+
+    @PluginMethod
     public void removeUpload(PluginCall call) {
         String id = call.getString("id");
         if (id == null || id.isEmpty()) {

--- a/ios/Sources/UploaderPlugin/UploaderPlugin.swift
+++ b/ios/Sources/UploaderPlugin/UploaderPlugin.swift
@@ -8,6 +8,7 @@ public class UploaderPlugin: CAPPlugin, CAPBridgedPlugin {
     public let jsName = "Uploader"
     public let pluginMethods: [CAPPluginMethod] = [
         CAPPluginMethod(name: "startUpload", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "uploadMultipart", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "removeUpload", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getPluginVersion", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "acknowledgeEvent", returnType: CAPPluginReturnPromise)
@@ -65,6 +66,40 @@ public class UploaderPlugin: CAPPlugin, CAPBridgedPlugin {
                 call.resolve(["id": id])
             } catch {
                 call.reject("Failed to start upload: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    @objc func uploadMultipart(_ call: CAPPluginCall) {
+        guard let serverUrl = call.getString("url"), !serverUrl.isEmpty else {
+            call.reject("Missing required parameter: url")
+            return
+        }
+        guard let filePath = call.getString("filePath"), !filePath.isEmpty else {
+            call.reject("Missing required parameter: filePath")
+            return
+        }
+        guard let fieldName = call.getString("fieldName"), !fieldName.isEmpty else {
+            call.reject("Missing required parameter: fieldName")
+            return
+        }
+
+        let headers = (call.getObject("headers") ?? [:]).compactMapValues { $0 as? String }
+        let fields = (call.getObject("fields") ?? [:]).compactMapValues { $0 as? String }
+        let options: [String: Any] = [
+            "headers": headers,
+            "parameters": fields,
+            "method": "POST",
+            "uploadType": "multipart",
+            "fileField": fieldName
+        ]
+
+        Task {
+            do {
+                let id = try await implementation.startUpload(filePath, serverUrl, options, maxRetries: 3)
+                call.resolve(["id": id])
+            } catch {
+                call.reject("Failed to start multipart upload: \(error.localizedDescription)")
             }
         }
     }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -32,6 +32,49 @@ export interface UploadFileOption {
   mimeType?: string;
 }
 
+/**
+ * Options for starting a single-file multipart upload.
+ *
+ * @since 8.3.2
+ */
+export interface UploadMultipartOptions {
+  /**
+   * The server URL endpoint where the multipart request should be sent.
+   *
+   * @since 8.3.2
+   */
+  url: string;
+
+  /**
+   * The local file path of the file to upload.
+   * Can be a file:// URL or an absolute path.
+   *
+   * @since 8.3.2
+   */
+  filePath: string;
+
+  /**
+   * The form field name for the uploaded file part.
+   *
+   * @since 8.3.2
+   */
+  fieldName: string;
+
+  /**
+   * Additional form fields to include in the multipart request.
+   *
+   * @since 8.3.2
+   */
+  fields?: { [key: string]: string };
+
+  /**
+   * HTTP headers to send with the upload request.
+   *
+   * @since 8.3.2
+   */
+  headers?: { [key: string]: string };
+}
+
 export interface uploadOption {
   /**
    * The local file path of the file to upload.
@@ -283,6 +326,30 @@ export interface UploaderPlugin {
    * ```
    */
   startUpload(options: uploadOption): Promise<{ id: string }>;
+
+  /**
+   * Start uploading a single file as multipart/form-data.
+   *
+   * This is a convenience API for backends that expect a named file field and
+   * additional form fields. Existing `startUpload` binary uploads are unchanged.
+   *
+   * @param options - Configuration for the multipart upload
+   * @returns Promise that resolves with the upload ID
+   * @throws Error if the upload fails to start
+   * @since 8.3.2
+   * @example
+   * ```typescript
+   * const { id } = await Uploader.uploadMultipart({
+   *   url: 'https://example.com/upload',
+   *   filePath: 'file:///path/to/file.jpg',
+   *   fieldName: 'photo',
+   *   fields: { albumId: '7' },
+   *   headers: { Authorization: 'Bearer token' },
+   * });
+   * console.log('Upload started with ID:', id);
+   * ```
+   */
+  uploadMultipart(options: UploadMultipartOptions): Promise<{ id: string }>;
 
   /**
    * Cancel and remove an ongoing upload.

--- a/src/web.ts
+++ b/src/web.ts
@@ -2,7 +2,7 @@ import { WebPlugin } from '@capacitor/core';
 import { openDB } from 'idb';
 
 import { PathHelper } from './PathHelper';
-import type { UploadFileOption, UploaderPlugin, uploadOption } from './definitions';
+import type { UploadFileOption, UploadMultipartOptions, UploaderPlugin, uploadOption } from './definitions';
 
 export class UploaderWeb extends WebPlugin implements UploaderPlugin {
   private uploads: Map<string, { controller: AbortController; retries: number }> = new Map();
@@ -18,6 +18,18 @@ export class UploaderWeb extends WebPlugin implements UploaderPlugin {
     this.doUpload(id, options);
 
     return { id };
+  }
+
+  async uploadMultipart(options: UploadMultipartOptions): Promise<{ id: string }> {
+    return this.startUpload({
+      filePath: options.filePath,
+      serverUrl: options.url,
+      headers: options.headers ?? {},
+      method: 'POST',
+      uploadType: 'multipart',
+      fileField: options.fieldName,
+      parameters: options.fields ?? {},
+    });
   }
 
   async removeUpload(options: { id: string }): Promise<void> {


### PR DESCRIPTION
## What changed
- Added `Uploader.uploadMultipart({ url, filePath, fieldName, fields?, headers? })` to TypeScript, web, iOS, and Android.
- Mapped the helper onto the existing multipart upload path by using `POST`, `multipart/form-data`, `fileField`, and `parameters` internally.
- Regenerated the README API docs from `src/definitions.ts`.

## Root cause / request
- Fixes #15.
- The issue asks for multipart uploads with custom form data. Current `main` already has multipart internals through `startUpload`, but not the small convenience API shape proposed in the issue comments.

## Impact
- Binary uploads through `startUpload` are unchanged.
- Apps can now call a simpler single-file multipart helper with a required form field name and optional fields/headers.

## Validation
- `bun install --frozen-lockfile`
- `bun run fmt`
- `bun run build`
- `bun run verify`
- `bun run lint` (exit 0; existing warnings remain non-blocking)
