### PR TITLE
fix(android): deliver background upload events to acknowledgeEvent

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor/uploader/UploaderPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor/uploader/UploaderPlugin.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.UUID;
 import net.gotev.uploadservice.data.UploadInfo;
 import net.gotev.uploadservice.network.ServerResponse;
-import net.gotev.uploadservice.observer.request.RequestObserver;
+import net.gotev.uploadservice.observer.request.GlobalRequestObserver;
 import net.gotev.uploadservice.observer.request.RequestObserverDelegate;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -36,6 +36,7 @@ public class UploaderPlugin extends Plugin {
     private final String pluginVersion = "8.3.7";
 
     private Uploader implementation;
+    private GlobalRequestObserver uploadObserver;
 
     private static final String CHANNEL_ID = "ee.forgr.capacitor.uploader.notification_channel_id";
     private static final String CHANNEL_NAME = "Uploader Notifications";
@@ -79,7 +80,7 @@ public class UploaderPlugin extends Plugin {
                 String eventId = keys.next();
                 JSONObject eventJson = pendingEvents.getJSONObject(eventId);
                 JSObject event = JSObject.fromJSONObject(eventJson);
-                notifyListeners("events", event);
+                notifyListeners("events", event, true);
             }
         } catch (JSONException e) {
             Log.e(TAG, "Failed to replay pending upload events", e);
@@ -100,11 +101,13 @@ public class UploaderPlugin extends Plugin {
     @Override
     public void load() {
         createNotificationChannel();
+        implementation = new Uploader(getContext().getApplicationContext());
 
-        // Create a request observer for all uploads
-        RequestObserver observer = new RequestObserver(
-            getContext().getApplicationContext(),
-            getActivity(),
+        // Registered against the Application, not the Activity lifecycle: an
+        // activity-bound observer unregisters on pause, which is exactly when
+        // background uploads finish and their events need persisting.
+        uploadObserver = new GlobalRequestObserver(
+            getActivity().getApplication(),
             new RequestObserverDelegate() {
                 @Override
                 public void onProgress(Context context, UploadInfo uploadInfo) {
@@ -163,8 +166,16 @@ public class UploaderPlugin extends Plugin {
             }
         );
 
-        implementation = new Uploader(getContext().getApplicationContext());
         replayPendingEvents();
+    }
+
+    @Override
+    protected void handleOnDestroy() {
+        if (uploadObserver != null) {
+            uploadObserver.unregister();
+            uploadObserver = null;
+        }
+        super.handleOnDestroy();
     }
 
     public static String getMimeType(String url) {

--- a/android/src/main/java/ee/forgr/capacitor/uploader/UploaderPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor/uploader/UploaderPlugin.java
@@ -103,9 +103,10 @@ public class UploaderPlugin extends Plugin {
         createNotificationChannel();
         implementation = new Uploader(getContext().getApplicationContext());
 
-        // Registered against the Application, not the Activity lifecycle: an
-        // activity-bound observer unregisters on pause, which is exactly when
-        // background uploads finish and their events need persisting.
+        // Registered against the Application for process lifetime — do not
+        // unregister in handleOnDestroy. Activity destroy (config change /
+        // background teardown) can happen while UploadService is still running;
+        // an activity-bound observer would miss those terminal events.
         uploadObserver = new GlobalRequestObserver(
             getActivity().getApplication(),
             new RequestObserverDelegate() {
@@ -167,15 +168,6 @@ public class UploaderPlugin extends Plugin {
         );
 
         replayPendingEvents();
-    }
-
-    @Override
-    protected void handleOnDestroy() {
-        if (uploadObserver != null) {
-            uploadObserver.unregister();
-            uploadObserver = null;
-        }
-        super.handleOnDestroy();
     }
 
     public static String getMimeType(String url) {

--- a/android/src/main/java/ee/forgr/capacitor/uploader/UploaderPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor/uploader/UploaderPlugin.java
@@ -14,11 +14,16 @@ import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
+import android.app.Application;
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import kotlin.jvm.functions.Function1;
 import net.gotev.uploadservice.data.UploadInfo;
 import net.gotev.uploadservice.network.ServerResponse;
 import net.gotev.uploadservice.observer.request.GlobalRequestObserver;
@@ -36,7 +41,6 @@ public class UploaderPlugin extends Plugin {
     private final String pluginVersion = "8.3.7";
 
     private Uploader implementation;
-    private GlobalRequestObserver uploadObserver;
 
     private static final String CHANNEL_ID = "ee.forgr.capacitor.uploader.notification_channel_id";
     private static final String CHANNEL_NAME = "Uploader Notifications";
@@ -46,44 +50,58 @@ public class UploaderPlugin extends Plugin {
     private static final String PENDING_EVENTS_KEY = "pending_events";
     private static final String TAG = "UploaderPlugin";
 
-    private void saveEventToPrefs(String eventId, JSObject event) {
-        SharedPreferences prefs = getContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
-        String existingJson = prefs.getString(PENDING_EVENTS_KEY, "{}");
-        try {
-            JSONObject pendingEvents = new JSONObject(existingJson);
-            pendingEvents.put(eventId, new JSONObject(event.toString()));
-            prefs.edit().putString(PENDING_EVENTS_KEY, pendingEvents.toString()).apply();
-        } catch (JSONException e) {
-            Log.e(TAG, "Failed to persist upload event", e);
+    // Process-scoped: one observer for the process, filtered to plugin-owned uploads.
+    private static final Set<String> OWNED_UPLOAD_IDS = ConcurrentHashMap.newKeySet();
+    private static final Object PENDING_EVENTS_LOCK = new Object();
+    private static final Object OBSERVER_LOCK = new Object();
+    private static GlobalRequestObserver processObserver;
+    private static Uploader processUploader;
+    private static WeakReference<UploaderPlugin> activePlugin = new WeakReference<>(null);
+
+    private static void saveEventToPrefs(Context context, String eventId, JSObject event) {
+        synchronized (PENDING_EVENTS_LOCK) {
+            SharedPreferences prefs = context.getApplicationContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+            String existingJson = prefs.getString(PENDING_EVENTS_KEY, "{}");
+            try {
+                JSONObject pendingEvents = new JSONObject(existingJson);
+                pendingEvents.put(eventId, new JSONObject(event.toString()));
+                prefs.edit().putString(PENDING_EVENTS_KEY, pendingEvents.toString()).apply();
+            } catch (JSONException e) {
+                Log.e(TAG, "Failed to persist upload event", e);
+            }
         }
     }
 
-    private void removeEventFromPrefs(String eventId) {
-        SharedPreferences prefs = getContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
-        String existingJson = prefs.getString(PENDING_EVENTS_KEY, "{}");
-        try {
-            JSONObject pendingEvents = new JSONObject(existingJson);
-            pendingEvents.remove(eventId);
-            prefs.edit().putString(PENDING_EVENTS_KEY, pendingEvents.toString()).apply();
-        } catch (JSONException e) {
-            Log.e(TAG, "Failed to remove upload event from prefs", e);
+    private static void removeEventFromPrefs(Context context, String eventId) {
+        synchronized (PENDING_EVENTS_LOCK) {
+            SharedPreferences prefs = context.getApplicationContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+            String existingJson = prefs.getString(PENDING_EVENTS_KEY, "{}");
+            try {
+                JSONObject pendingEvents = new JSONObject(existingJson);
+                pendingEvents.remove(eventId);
+                prefs.edit().putString(PENDING_EVENTS_KEY, pendingEvents.toString()).apply();
+            } catch (JSONException e) {
+                Log.e(TAG, "Failed to remove upload event from prefs", e);
+            }
         }
     }
 
     private void replayPendingEvents() {
-        SharedPreferences prefs = getContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
-        String existingJson = prefs.getString(PENDING_EVENTS_KEY, "{}");
-        try {
-            JSONObject pendingEvents = new JSONObject(existingJson);
-            Iterator<String> keys = pendingEvents.keys();
-            while (keys.hasNext()) {
-                String eventId = keys.next();
-                JSONObject eventJson = pendingEvents.getJSONObject(eventId);
-                JSObject event = JSObject.fromJSONObject(eventJson);
-                notifyListeners("events", event, true);
+        synchronized (PENDING_EVENTS_LOCK) {
+            SharedPreferences prefs = getContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+            String existingJson = prefs.getString(PENDING_EVENTS_KEY, "{}");
+            try {
+                JSONObject pendingEvents = new JSONObject(existingJson);
+                Iterator<String> keys = pendingEvents.keys();
+                while (keys.hasNext()) {
+                    String eventId = keys.next();
+                    JSONObject eventJson = pendingEvents.getJSONObject(eventId);
+                    JSObject event = JSObject.fromJSONObject(eventJson);
+                    notifyListeners("events", event, true);
+                }
+            } catch (JSONException e) {
+                Log.e(TAG, "Failed to replay pending upload events", e);
             }
-        } catch (JSONException e) {
-            Log.e(TAG, "Failed to replay pending upload events", e);
         }
     }
 
@@ -98,75 +116,116 @@ public class UploaderPlugin extends Plugin {
         }
     }
 
+    private static UploaderPlugin currentPlugin() {
+        return activePlugin.get();
+    }
+
+    private static void emitEvent(String name, JSObject event, boolean retainUntilConsumed) {
+        UploaderPlugin plugin = currentPlugin();
+        if (plugin == null) {
+            return;
+        }
+        if (retainUntilConsumed) {
+            plugin.notifyListeners(name, event, true);
+        } else {
+            plugin.notifyListeners(name, event);
+        }
+    }
+
+    private static void clearTempBody(String uploadId) {
+        if (processUploader != null) {
+            processUploader.clearTempMultipartBody(uploadId);
+        }
+    }
+
+    private static void releaseUpload(String uploadId) {
+        clearTempBody(uploadId);
+        OWNED_UPLOAD_IDS.remove(uploadId);
+    }
+
+    private static void ensureProcessObserver(Application application) {
+        synchronized (OBSERVER_LOCK) {
+            if (processObserver != null) {
+                return;
+            }
+            if (processUploader == null) {
+                processUploader = new Uploader(application);
+            }
+            // Keep observer for process lifetime. Weak plugin ref avoids retaining Bridge/WebView
+            // after Activity destroy; register once to avoid duplicate receivers.
+            processObserver =
+                new GlobalRequestObserver(
+                    application,
+                    new RequestObserverDelegate() {
+                        @Override
+                        public void onProgress(Context context, UploadInfo uploadInfo) {
+                            JSObject event = new JSObject();
+                            event.put("name", "uploading");
+                            JSObject payload = new JSObject();
+                            payload.put("percent", uploadInfo.getProgressPercent());
+                            event.put("payload", payload);
+                            event.put("id", uploadInfo.getUploadId());
+                            emitEvent("events", event, false);
+                        }
+
+                        @Override
+                        public void onSuccess(Context context, UploadInfo uploadInfo, ServerResponse serverResponse) {
+                            clearTempBody(uploadInfo.getUploadId());
+                            JSObject event = new JSObject();
+                            event.put("name", "completed");
+                            JSObject payload = new JSObject();
+                            payload.put("statusCode", serverResponse.getCode());
+                            event.put("payload", payload);
+                            event.put("id", uploadInfo.getUploadId());
+                            String eventId = UUID.randomUUID().toString();
+                            event.put("eventId", eventId);
+                            saveEventToPrefs(context, eventId, event);
+                            emitEvent("events", event, true);
+                        }
+
+                        @Override
+                        public void onError(Context context, UploadInfo uploadInfo, Throwable exception) {
+                            clearTempBody(uploadInfo.getUploadId());
+                            JSObject event = new JSObject();
+                            event.put("name", "failed");
+                            JSObject payload = new JSObject();
+                            payload.put("error", exception.getMessage());
+                            event.put("payload", payload);
+                            event.put("id", uploadInfo.getUploadId());
+                            String eventId = UUID.randomUUID().toString();
+                            event.put("eventId", eventId);
+                            saveEventToPrefs(context, eventId, event);
+                            emitEvent("events", event, true);
+                        }
+
+                        @Override
+                        public void onCompleted(Context context, UploadInfo uploadInfo) {
+                            releaseUpload(uploadInfo.getUploadId());
+                            JSObject event = new JSObject();
+                            event.put("name", "finished");
+                            event.put("id", uploadInfo.getUploadId());
+                            emitEvent("events", event, false);
+                        }
+
+                        @Override
+                        public void onCompletedWhileNotObserving() {
+                            UploaderPlugin plugin = currentPlugin();
+                            if (plugin != null) {
+                                plugin.replayPendingEvents();
+                            }
+                        }
+                    },
+                    (Function1<UploadInfo, Boolean>) uploadInfo -> OWNED_UPLOAD_IDS.contains(uploadInfo.getUploadId())
+                );
+        }
+    }
+
     @Override
     public void load() {
         createNotificationChannel();
-        implementation = new Uploader(getContext().getApplicationContext());
-
-        // Registered against the Application for process lifetime — do not
-        // unregister in handleOnDestroy. Activity destroy (config change /
-        // background teardown) can happen while UploadService is still running;
-        // an activity-bound observer would miss those terminal events.
-        uploadObserver = new GlobalRequestObserver(
-            getActivity().getApplication(),
-            new RequestObserverDelegate() {
-                @Override
-                public void onProgress(Context context, UploadInfo uploadInfo) {
-                    JSObject event = new JSObject();
-                    event.put("name", "uploading");
-                    JSObject payload = new JSObject();
-                    payload.put("percent", uploadInfo.getProgressPercent());
-                    event.put("payload", payload);
-                    event.put("id", uploadInfo.getUploadId());
-                    notifyListeners("events", event);
-                }
-
-                @Override
-                public void onSuccess(Context context, UploadInfo uploadInfo, ServerResponse serverResponse) {
-                    implementation.clearTempMultipartBody(uploadInfo.getUploadId());
-                    JSObject event = new JSObject();
-                    event.put("name", "completed");
-                    JSObject payload = new JSObject();
-                    payload.put("statusCode", serverResponse.getCode());
-                    event.put("payload", payload);
-                    event.put("id", uploadInfo.getUploadId());
-                    String eventId = UUID.randomUUID().toString();
-                    event.put("eventId", eventId);
-                    saveEventToPrefs(eventId, event);
-                    notifyListeners("events", event, true);
-                }
-
-                @Override
-                public void onError(Context context, UploadInfo uploadInfo, Throwable exception) {
-                    implementation.clearTempMultipartBody(uploadInfo.getUploadId());
-                    JSObject event = new JSObject();
-                    event.put("name", "failed");
-                    JSObject payload = new JSObject();
-                    payload.put("error", exception.getMessage());
-                    event.put("payload", payload);
-                    event.put("id", uploadInfo.getUploadId());
-                    String eventId = UUID.randomUUID().toString();
-                    event.put("eventId", eventId);
-                    saveEventToPrefs(eventId, event);
-                    notifyListeners("events", event, true);
-                }
-
-                @Override
-                public void onCompleted(Context context, UploadInfo uploadInfo) {
-                    implementation.clearTempMultipartBody(uploadInfo.getUploadId());
-                    JSObject event = new JSObject();
-                    event.put("name", "finished");
-                    event.put("id", uploadInfo.getUploadId());
-                    notifyListeners("events", event);
-                }
-
-                @Override
-                public void onCompletedWhileNotObserving() {
-                    replayPendingEvents();
-                }
-            }
-        );
-
+        activePlugin = new WeakReference<>(this);
+        ensureProcessObserver(getActivity().getApplication());
+        implementation = processUploader;
         replayPendingEvents();
     }
 
@@ -253,6 +312,7 @@ public class UploaderPlugin extends Plugin {
                 maxRetries,
                 uploadType
             );
+            OWNED_UPLOAD_IDS.add(id);
             JSObject result = new JSObject();
             result.put("id", id);
             call.resolve(result);
@@ -293,6 +353,7 @@ public class UploaderPlugin extends Plugin {
             filesToUpload.add(new Uploader.UploadFile(localFilePath, fieldName, mimeType));
 
             String id = implementation.startUpload(filesToUpload, serverUrl, headers, fields, "POST", "File Upload", 2, "multipart");
+            OWNED_UPLOAD_IDS.add(id);
             JSObject result = new JSObject();
             result.put("id", id);
             call.resolve(result);
@@ -309,6 +370,7 @@ public class UploaderPlugin extends Plugin {
             return;
         }
         try {
+            OWNED_UPLOAD_IDS.remove(id);
             implementation.removeUpload(id);
             call.resolve();
         } catch (Exception e) {
@@ -372,7 +434,7 @@ public class UploaderPlugin extends Plugin {
             call.reject("Missing required parameter: eventId");
             return;
         }
-        removeEventFromPrefs(eventId);
+        removeEventFromPrefs(getContext(), eventId);
         call.resolve();
     }
 

--- a/android/src/main/java/ee/forgr/capacitor/uploader/UploaderPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor/uploader/UploaderPlugin.java
@@ -132,7 +132,7 @@ public class UploaderPlugin extends Plugin {
                     String eventId = UUID.randomUUID().toString();
                     event.put("eventId", eventId);
                     saveEventToPrefs(eventId, event);
-                    notifyListeners("events", event);
+                    notifyListeners("events", event, true);
                 }
 
                 @Override
@@ -147,7 +147,7 @@ public class UploaderPlugin extends Plugin {
                     String eventId = UUID.randomUUID().toString();
                     event.put("eventId", eventId);
                     saveEventToPrefs(eventId, event);
-                    notifyListeners("events", event);
+                    notifyListeners("events", event, true);
                 }
 
                 @Override

--- a/android/src/main/java/ee/forgr/capacitor/uploader/UploaderPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor/uploader/UploaderPlugin.java
@@ -1,5 +1,6 @@
 package ee.forgr.capacitor.uploader;
 
+import android.app.Application;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
@@ -14,7 +15,6 @@ import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
-import android.app.Application;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -158,73 +158,72 @@ public class UploaderPlugin extends Plugin {
             }
             // Keep observer for process lifetime. Weak plugin ref avoids retaining Bridge/WebView
             // after Activity destroy; register once to avoid duplicate receivers.
-            processObserver =
-                new GlobalRequestObserver(
-                    application,
-                    new RequestObserverDelegate() {
-                        @Override
-                        public void onProgress(Context context, UploadInfo uploadInfo) {
-                            JSObject event = new JSObject();
-                            event.put("name", "uploading");
-                            JSObject payload = new JSObject();
-                            payload.put("percent", uploadInfo.getProgressPercent());
-                            event.put("payload", payload);
-                            event.put("id", uploadInfo.getUploadId());
-                            emitEvent("events", event, false);
-                        }
+            processObserver = new GlobalRequestObserver(
+                application,
+                new RequestObserverDelegate() {
+                    @Override
+                    public void onProgress(Context context, UploadInfo uploadInfo) {
+                        JSObject event = new JSObject();
+                        event.put("name", "uploading");
+                        JSObject payload = new JSObject();
+                        payload.put("percent", uploadInfo.getProgressPercent());
+                        event.put("payload", payload);
+                        event.put("id", uploadInfo.getUploadId());
+                        emitEvent("events", event, false);
+                    }
 
-                        @Override
-                        public void onSuccess(Context context, UploadInfo uploadInfo, ServerResponse serverResponse) {
-                            clearTempBody(uploadInfo.getUploadId());
-                            JSObject event = new JSObject();
-                            event.put("name", "completed");
-                            JSObject payload = new JSObject();
-                            payload.put("statusCode", serverResponse.getCode());
-                            event.put("payload", payload);
-                            event.put("id", uploadInfo.getUploadId());
-                            String eventId = UUID.randomUUID().toString();
-                            event.put("eventId", eventId);
-                            saveEventToPrefs(context, eventId, event);
-                            emitEvent("events", event, true);
-                        }
+                    @Override
+                    public void onSuccess(Context context, UploadInfo uploadInfo, ServerResponse serverResponse) {
+                        clearTempBody(uploadInfo.getUploadId());
+                        JSObject event = new JSObject();
+                        event.put("name", "completed");
+                        JSObject payload = new JSObject();
+                        payload.put("statusCode", serverResponse.getCode());
+                        event.put("payload", payload);
+                        event.put("id", uploadInfo.getUploadId());
+                        String eventId = UUID.randomUUID().toString();
+                        event.put("eventId", eventId);
+                        saveEventToPrefs(context, eventId, event);
+                        emitEvent("events", event, true);
+                    }
 
-                        @Override
-                        public void onError(Context context, UploadInfo uploadInfo, Throwable exception) {
-                            clearTempBody(uploadInfo.getUploadId());
-                            JSObject event = new JSObject();
-                            event.put("name", "failed");
-                            JSObject payload = new JSObject();
-                            payload.put("error", exception.getMessage());
-                            event.put("payload", payload);
-                            event.put("id", uploadInfo.getUploadId());
-                            String eventId = UUID.randomUUID().toString();
-                            event.put("eventId", eventId);
-                            saveEventToPrefs(context, eventId, event);
-                            emitEvent("events", event, true);
-                        }
+                    @Override
+                    public void onError(Context context, UploadInfo uploadInfo, Throwable exception) {
+                        clearTempBody(uploadInfo.getUploadId());
+                        JSObject event = new JSObject();
+                        event.put("name", "failed");
+                        JSObject payload = new JSObject();
+                        payload.put("error", exception.getMessage());
+                        event.put("payload", payload);
+                        event.put("id", uploadInfo.getUploadId());
+                        String eventId = UUID.randomUUID().toString();
+                        event.put("eventId", eventId);
+                        saveEventToPrefs(context, eventId, event);
+                        emitEvent("events", event, true);
+                    }
 
-                        @Override
-                        public void onCompleted(Context context, UploadInfo uploadInfo) {
-                            releaseUpload(uploadInfo.getUploadId());
-                            JSObject event = new JSObject();
-                            event.put("name", "finished");
-                            event.put("id", uploadInfo.getUploadId());
-                            emitEvent("events", event, false);
-                        }
+                    @Override
+                    public void onCompleted(Context context, UploadInfo uploadInfo) {
+                        releaseUpload(uploadInfo.getUploadId());
+                        JSObject event = new JSObject();
+                        event.put("name", "finished");
+                        event.put("id", uploadInfo.getUploadId());
+                        emitEvent("events", event, false);
+                    }
 
-                        @Override
-                        public void onCompletedWhileNotObserving() {
-                            if (!pluginAttached) {
-                                return;
-                            }
-                            UploaderPlugin plugin = currentPlugin();
-                            if (plugin != null && plugin.getBridge() != null) {
-                                plugin.replayPendingEvents();
-                            }
+                    @Override
+                    public void onCompletedWhileNotObserving() {
+                        if (!pluginAttached) {
+                            return;
                         }
-                    },
-                    (Function1<UploadInfo, Boolean>) uploadInfo -> OWNED_UPLOAD_IDS.contains(uploadInfo.getUploadId())
-                );
+                        UploaderPlugin plugin = currentPlugin();
+                        if (plugin != null && plugin.getBridge() != null) {
+                            plugin.replayPendingEvents();
+                        }
+                    }
+                },
+                (Function1<UploadInfo, Boolean>) (uploadInfo) -> OWNED_UPLOAD_IDS.contains(uploadInfo.getUploadId())
+            );
         }
     }
 

--- a/android/src/main/java/ee/forgr/capacitor/uploader/UploaderPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor/uploader/UploaderPlugin.java
@@ -57,6 +57,8 @@ public class UploaderPlugin extends Plugin {
     private static GlobalRequestObserver processObserver;
     private static Uploader processUploader;
     private static WeakReference<UploaderPlugin> activePlugin = new WeakReference<>(null);
+    // Cleared in handleOnDestroy so emitEvent no-ops while Activity/Bridge is tearing down.
+    private static volatile boolean pluginAttached = false;
 
     private static void saveEventToPrefs(Context context, String eventId, JSObject event) {
         synchronized (PENDING_EVENTS_LOCK) {
@@ -121,8 +123,11 @@ public class UploaderPlugin extends Plugin {
     }
 
     private static void emitEvent(String name, JSObject event, boolean retainUntilConsumed) {
+        if (!pluginAttached) {
+            return;
+        }
         UploaderPlugin plugin = currentPlugin();
-        if (plugin == null) {
+        if (plugin == null || plugin.getBridge() == null) {
             return;
         }
         if (retainUntilConsumed) {
@@ -209,8 +214,11 @@ public class UploaderPlugin extends Plugin {
 
                         @Override
                         public void onCompletedWhileNotObserving() {
+                            if (!pluginAttached) {
+                                return;
+                            }
                             UploaderPlugin plugin = currentPlugin();
-                            if (plugin != null) {
+                            if (plugin != null && plugin.getBridge() != null) {
                                 plugin.replayPendingEvents();
                             }
                         }
@@ -224,9 +232,20 @@ public class UploaderPlugin extends Plugin {
     public void load() {
         createNotificationChannel();
         activePlugin = new WeakReference<>(this);
+        pluginAttached = true;
         ensureProcessObserver(getActivity().getApplication());
         implementation = processUploader;
         replayPendingEvents();
+    }
+
+    @Override
+    protected void handleOnDestroy() {
+        // Detach the plugin sink only — keep processObserver registered for background uploads.
+        if (activePlugin.get() == this) {
+            pluginAttached = false;
+            activePlugin.clear();
+        }
+        super.handleOnDestroy();
     }
 
     public static String getMimeType(String url) {


### PR DESCRIPTION
The `acknowledgeEvent` feature added in #165 cannot currently deliver background upload events. Two independent problems stop it, and this PR fixes both.

## 1. Terminal events are never persisted while the app is backgrounded

`saveEventToPrefs(...)` is only reached from inside the `RequestObserverDelegate` callbacks. Those callbacks belong to `RequestObserver`, which this library binds to the activity lifecycle:

```kotlin
// RequestObserver.kt
init { lifecycleOwner.lifecycle.addObserver(this) }

@OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
override fun unregister() { super.unregister() }
```

So the observer unregisters the moment the activity pauses — exactly when a background upload finishes. The delegate never fires, and nothing is written to `SharedPreferences`. The feature therefore persists only *foreground* completions, which are the ones that never needed persisting.

`onCompletedWhileNotObserving()` cannot cover the gap either. `RequestObserver.register()` only invokes it when `subscribedUploadID != null`, and that field is set solely by `observer.subscribe(request)`, which the plugin never calls. The callback is unreachable.

**Fix:** use `GlobalRequestObserver`, which registers a plain `BroadcastReceiver` against the `Application` and is not tied to any activity lifecycle. The plugin keeps a reference and unregisters it in `handleOnDestroy()` so the receiver is not leaked.

## 2. Replayed events are dropped at cold start

`replayPendingEvents()` is called at the end of `load()`, which runs during bridge construction — before the web view has evaluated any JavaScript, so no listener is attached yet. It emitted through the two-argument overload:

```java
// Plugin.java
protected void notifyListeners(String eventName, JSObject data) {
    notifyListeners(eventName, data, false);   // retainUntilConsumed = false
}
```

With `retainUntilConsumed = false`, an event with no current listener is discarded. Combined with problem 1, replay never delivered anything to anyone.

**Fix:** replay and both terminal callbacks (`onSuccess`, `onError`) now use `notifyListeners("events", event, true)`.

An earlier revision of this PR retained only on the replay path, on the assumption that live events always have a listener and retaining them would double-deliver. That was wrong, and thanks to the review for catching it — `Plugin.notifyListeners` retains *only* when the listener list is empty, and returns without retaining when listeners exist, so `retainUntilConsumed = true` cannot double-deliver:

```java
if (listeners == null || listeners.isEmpty()) {
    if (retainUntilConsumed) { /* retain */ }
    return;
}
// listeners present: deliver, never retain
```

It also closes a real gap. Now that a global observer delivers events while backgrounded, a terminal event can arrive when no listener is attached — for example after the consumer removed its listener on a timeout, or in the window between `load()` and the web view registering listeners. Without retention that event was persisted but not surfaced until the *next* cold start, because `replayPendingEvents()` had already run.

`onProgress` stays non-retaining: progress is not persisted, and a stale percentage delivered later is meaningless. `onCompleted` likewise, since it carries no `eventId`.

## 3. Ordering

`implementation` is now assigned before the observer is constructed. The delegate's `onSuccess`/`onError` call `implementation.clearTempMultipartBody(...)`, and with a globally-registered receiver an event can arrive as soon as the observer exists — previously `implementation` was still null at that point.

## Note for consumers

These fixes make persistence and replay work, which means the cache genuinely fills now. Apps must call `acknowledgeEvent(eventId)` on terminal events or `SharedPreferences` grows without bound — it is a single JSON blob rewritten on every upload, so unacknowledged entries also make each write progressively more expensive. That may be worth calling out more prominently in the README, since the current example does not show it.

## Verification

Built against Capacitor 8.5.0 (`assembleRelease`, minify + ProGuard) and exercised in a production app: uploads to an S3 presigned `PUT`, backgrounded mid-transfer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Upload progress and completion events now remain available reliably across activity lifecycle changes.
  * Pending, successful, and failed upload notifications are delivered consistently.
* **Improvements**
  * Upload monitoring is initialized earlier to improve event reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->